### PR TITLE
Add option to set the Azure instance region

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,14 @@ markdownTranslate({
   src: pathToSrcFile,
   from: languageToTranslateFrom,
   to: languageToTranslateTo,
-  subscriptionKey: yourSubscriptionKey
+  subscriptionKey: yourSubscriptionKey,
+  region: theRegionOfYourAzureInstance
 }).then(res => {
   // deal with result
 })
 ```
 
+Note that there are some opinionated defaults: from is by default 'en', to 'zh'.
+The region argument is optional.
 
 

--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ npm install markdown-translator
 ```javascript
 const markdownTranslate = require('markdown-translator')
 markdownTranslate({
-  src,
-  from,
-  to,
-  subscriptionKey
+  src: pathToSrcFile,
+  from: languageToTranslateFrom,
+  to: languageToTranslateTo,
+  subscriptionKey: yourSubscriptionKey
 }).then(res => {
   // deal with result
 })

--- a/cli.js
+++ b/cli.js
@@ -34,9 +34,10 @@ program
   .option('-S, --src [src]', 'src file')
   .option('-D, --dest [dest]', 'dest file')
   .option('-F, --from [from]', 'src lang')
+  .option('-R, --region [region]', 'Azure region')
   .option('-T, --to [to]', 'dest lang')
   .option('-K, --key [key]', 'TRANSLATOR_TEXT_KEY')
-  .action(function({ src, dest, from, to, key }) {
+  .action(function({ src, dest, from, region, to, key }) {
     const srcPath = path.resolve(process.cwd(), src);
     const destPath = path.resolve(process.cwd(), dest);
     const subscriptionKey = key || config.key;
@@ -44,7 +45,8 @@ program
       src: srcPath,
       from,
       to,
-      subscriptionKey
+      subscriptionKey,
+      region
     }).then(data => {
       const writeStream = fs.createWriteStream(destPath);
       writeStream.write(data, err => {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const {parseToTree, getTextTobeTranslated, stringifyToDoc} = require('./lib/pars
 const {translate} = require('./lib/translateByMicrosoft');
 
 module.exports = ({
-  src, from, to, subscriptionKey
+  src, from, to, subscriptionKey, region
 }) => {
   return new Promise((resolve, reject) => {
     const tree = parseToTree(src);
@@ -26,7 +26,7 @@ module.exports = ({
   
     for (let eachTextArr of chunkTextArr) {
       translatePromises.push(translate(eachTextArr, {
-        from, to, subscriptionKey
+        from, to, subscriptionKey, region
       }));
     }
   

--- a/lib/translateByMicrosoft.js
+++ b/lib/translateByMicrosoft.js
@@ -16,7 +16,8 @@ module.exports.translate = (textArr, {
       url: 'translate',
       qs: merge({
         'api-version': '3.0',
-        'to': 'zh',
+        'from': 'en',
+        'to': 'zh'
       }, { from, to }),
       headers: {
         'Ocp-Apim-Subscription-Key': subscriptionKey,

--- a/lib/translateByMicrosoft.js
+++ b/lib/translateByMicrosoft.js
@@ -3,13 +3,13 @@ const request = require('request');
 const uuidv4 = require('uuid/v4');
 
 module.exports.translate = (textArr, {
-  from, to, subscriptionKey
+  from, to, subscriptionKey, region
 }) => {
   return new Promise((resolve, reject) => {
     if (!subscriptionKey) {
       reject(new Error('Your subscription key is not set.'))
     };
-    
+
     const options = {
       method: 'POST',
       baseUrl: 'https://api.cognitive.microsofttranslator.com/',
@@ -17,7 +17,7 @@ module.exports.translate = (textArr, {
       qs: merge({
         'api-version': '3.0',
         'to': 'zh',
-      }, {from, to}),
+      }, { from, to }),
       headers: {
         'Ocp-Apim-Subscription-Key': subscriptionKey,
         'Content-type': 'application/json',
@@ -26,9 +26,13 @@ module.exports.translate = (textArr, {
       body: textArr,
       json: true,
     };
-    
-    request(options, function(err, res, body){
-      if(err) {
+
+    if (region) {
+      options.headers['Ocp-Apim-Subscription-Region'] = region;
+    }
+
+    request(options, function (err, res, body) {
+      if (err) {
         reject(err);
       }
       resolve(body);


### PR DESCRIPTION
Thanks for this useful library!

This fixes errors such as `{"error":{"code":401000,"message":"The request is not authorized because credentials are missing or invalid."}}%`, respectively `TypeError: Cannot read property '0' of undefined at /Users/(...)/node_modules/markdown-translator/index.js:40:45`.

Also, it improves the README insofar as it helps to not make a mistake I made by blindly copying the example.